### PR TITLE
Add additional unit tests for MarkdownToRtf

### DIFF
--- a/MarkdownToRtf.Tests/MarkdownToRtfConverterTests.cs
+++ b/MarkdownToRtf.Tests/MarkdownToRtfConverterTests.cs
@@ -127,5 +127,57 @@ namespace MarkdownToRtf.Tests
             // The converter should escape them (\\, \{, \})
             Assert.Contains(@"Special chars: \\ \{ \}", rtf);
         }
+
+        [Fact]
+        public void Convert_CodeInline_UsesMonospaceFont()
+        {
+            // Arrange
+            string markdown = "Example with `code` inline.";
+
+            // Act
+            string rtf = MarkdownToRtfConverter.Convert(markdown);
+
+            // Assert
+            Assert.Contains(@"\f1 code\f0", rtf);
+        }
+
+        [Fact]
+        public void Convert_Link_IncludesUnderline()
+        {
+            // Arrange
+            string markdown = "See [link](https://example.com) here.";
+
+            // Act
+            string rtf = MarkdownToRtfConverter.Convert(markdown);
+
+            // Assert
+            Assert.Contains(@"\ul https://example.com\ulnone", rtf);
+        }
+
+        [Fact]
+        public void Convert_LineBreak_AddsRtfLine()
+        {
+            // Arrange - two spaces before newline forces a line break
+            string markdown = "Line1  \nLine2";
+
+            // Act
+            string rtf = MarkdownToRtfConverter.Convert(markdown);
+
+            // Assert
+            Assert.Contains(@"\line", rtf);
+        }
+
+        [Fact]
+        public void Convert_Heading2_UsesSmallerFont()
+        {
+            // Arrange
+            string markdown = "## Second Level";
+
+            // Act
+            string rtf = MarkdownToRtfConverter.Convert(markdown);
+
+            // Assert - heading level 2 maps to \fs28
+            Assert.Contains(@"\fs28", rtf);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand test coverage of MarkdownToRtfConverter
  - add tests for code spans, links, heading level 2, and line breaks
- tests also verify that special characters remain escaped

## Testing
- `dotnet test MarkdownToRtf.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851914e9aac832687dd4f972915bf9e