### PR TITLE
Add block quote support

### DIFF
--- a/MarkdownToRtf.Tests/MarkdownToRtfConverterTests.cs
+++ b/MarkdownToRtf.Tests/MarkdownToRtfConverterTests.cs
@@ -195,5 +195,19 @@ namespace MarkdownToRtf.Tests
             Assert.Contains(@"\fs28", rtf);
 
         }
+
+        [Fact]
+        public void Convert_BlockQuote_AddsIndent()
+        {
+            // Arrange
+            string markdown = "> quoted";
+
+            // Act
+            string rtf = MarkdownToRtfConverter.Convert(markdown);
+
+            // Assert
+            Assert.Contains(@"\li300", rtf);
+            Assert.Contains("quoted", rtf);
+        }
     }
 }

--- a/MarkdownToRtf/MarkdownToRtfConverter.cs
+++ b/MarkdownToRtf/MarkdownToRtfConverter.cs
@@ -31,28 +31,7 @@ namespace MarkdownToRtf
             // 3) Walk the document blocks
             foreach (var block in document)
             {
-                switch (block)
-                {
-                    case HeadingBlock headingBlock:
-                        ConvertHeadingBlock(rtfBuilder, headingBlock);
-                        break;
-
-                    case ParagraphBlock paragraphBlock:
-                        ConvertParagraphBlock(rtfBuilder, paragraphBlock);
-                        break;
-
-                    case ListBlock listBlock:
-                        ConvertListBlock(rtfBuilder, listBlock);
-                        break;
-
-                    case ThematicBreakBlock thematicBreakBlock:
-                        ConvertThematicBreakBlock(rtfBuilder, thematicBreakBlock);
-                        break;
-
-                    default:
-                        // Unhandled block type; extend as needed
-                        break;
-                }
+                ConvertBlock(rtfBuilder, block);
             }
 
             // Close the RTF document
@@ -142,6 +121,59 @@ namespace MarkdownToRtf
         private static void ConvertThematicBreakBlock(StringBuilder rtf, ThematicBreakBlock hrBlock)
         {
             rtf.AppendLine(@"\pard\brdrb\brdrs\brdrw10\brsp20\par");
+        }
+
+        /// <summary>
+        /// Dispatches block conversion so it can be called recursively.
+        /// </summary>
+        private static void ConvertBlock(StringBuilder rtf, Block block)
+        {
+            switch (block)
+            {
+                case HeadingBlock headingBlock:
+                    ConvertHeadingBlock(rtf, headingBlock);
+                    break;
+
+                case ParagraphBlock paragraphBlock:
+                    ConvertParagraphBlock(rtf, paragraphBlock);
+                    break;
+
+                case ListBlock listBlock:
+                    ConvertListBlock(rtf, listBlock);
+                    break;
+
+                case ThematicBreakBlock thematicBreakBlock:
+                    ConvertThematicBreakBlock(rtf, thematicBreakBlock);
+                    break;
+
+                case QuoteBlock quoteBlock:
+                    ConvertQuoteBlock(rtf, quoteBlock);
+                    break;
+
+                default:
+                    // Unhandled block type; extend as needed
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Handles block quotes.
+        /// </summary>
+        private static void ConvertQuoteBlock(StringBuilder rtf, QuoteBlock quoteBlock)
+        {
+            foreach (var subBlock in quoteBlock)
+            {
+                if (subBlock is ParagraphBlock paragraph)
+                {
+                    rtf.Append(@"\pard\li300\sa180\fs20 ");
+                    ConvertInline(rtf, paragraph.Inline);
+                    rtf.AppendLine(@"\par");
+                }
+                else
+                {
+                    ConvertBlock(rtf, subBlock);
+                }
+            }
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - Italic (`*italic*`)
   - Underline (`__underline__`)
   - Ordered and unordered lists (`1. Item`, `- Bullet`)
+  - Block quotes (`> Quote`)
 - **RTF output**: Generates a valid RTF string that can be saved to a file or rendered in controls like `RichTextBox`.
 
 
@@ -84,7 +85,6 @@ Output RTF (simplified for readability):
 - Nested lists
 - Clickable links
 - Images
-- Block quotes
 - Code blocks
 - Horizontal rules
 - Tables


### PR DESCRIPTION
## Summary
- implement quote block conversion
- add quote test coverage
- document block quotes as supported and move from planned

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851957818ac8326972a5621f51cbf86